### PR TITLE
Speed up log <--> linear visibility transforms, add absolute bias analysis function

### DIFF
--- a/slar/analysis.py
+++ b/slar/analysis.py
@@ -29,3 +29,24 @@ def vis_bias(target : torch.Tensor, pred : torch.Tensor, threshold : float = 0.)
     bias = (2 * torch.abs(a-b) / (a+b)).mean()
     return bias
 
+def abs_bias(target: torch.Tensor, pred : torch.Tensor, random=0):
+    '''
+    Function to compute the absolute bias (the mean of |target - pred|)
+    
+    Parameters
+    ----------
+    target : torch.Tensor
+        Some reference target based on which the bias is calculated.
+    pred : torch.Tensor
+        Prediction for target on which which the bias is calculated.
+        
+    Returns
+    -------
+    torch.Tensor
+        The model absolute bias.
+
+    '''
+    if target.shape != pred.shape:
+        raise ValueError(f'target and pred must have the same shape {(*target.shape,)} != {(*pred.shape,)}')
+    
+    return torch.abs(target - pred).mean()

--- a/slar/optimizers.py
+++ b/slar/optimizers.py
@@ -62,8 +62,12 @@ def optimizer_factory(params,cfg):
         An instance of an optimizer with the parameters eitehr configured
         by the input or loaded from a checkpoint file.
     '''
-    opt_class = cfg['train']['optimizer_class']
-    opt_param = cfg['train']['optimizer_param']
+    if 'optimizer_class' in cfg['train']:
+        opt_class = cfg['train']['optimizer_class']
+        opt_param = cfg['train']['optimizer_param']
+    else:
+        opt_class = cfg['train']['optimizer']['name']
+        opt_param = cfg['train']['optimizer']['parameters']
 
     if not hasattr(torch.optim, opt_class):
         raise RuntimeError(f'torch.optim has no optimizer called {opt_class}')

--- a/slar/transform.py
+++ b/slar/transform.py
@@ -1,5 +1,6 @@
 import torch
 from functools import partial
+import numpy as np
 
 def xform_vis(x, vmax=1, eps=1e-7, sin_out=False):
     r'''
@@ -32,10 +33,10 @@ def xform_vis(x, vmax=1, eps=1e-7, sin_out=False):
     torch.Tensor
         The log-scale visibility value.
     '''
-    eps=torch.as_tensor(eps,device=x.device)
-    vmax=torch.as_tensor(vmax,device=x.device)
-    y0 = torch.log10(eps)
-    y1 = torch.log10(vmax+ eps)
+    # eps=torch.as_tensor(eps,device=x.device)
+    # vmax=torch.as_tensor(vmax,device=x.device)
+    y0 = np.log10(eps)
+    y1 = np.log10(vmax+ eps)
 
     y = torch.log10(x + eps)
     y -= y0
@@ -67,10 +68,10 @@ def inv_xform_vis(y, vmax=1, eps=1e-7, sin_out=False):
     torch.Tensor
         The linear-scale visibility value.
     '''
-    eps=torch.as_tensor(eps,device=y.device)
-    vmax=torch.as_tensor(vmax,device=y.device)
-    y0 = torch.log10(eps)
-    y1 = torch.log10(vmax + eps)
+    # eps=torch.as_tensor(eps,device=y.device)
+    # vmax=torch.as_tensor(vmax,device=y.device)
+    y0 = np.log10(eps)
+    y1 = np.log10(vmax + eps)
 
     if sin_out:
         y = (y+1)/2


### PR DESCRIPTION
If using `xform_vis` or `inv_xform_vis` for training (like in [SOptimizer](https://github.com/CIDeR-ML/siren-pfmatch/blob/develop/pfmatch/apps/soptimizer.py) in `pfmatch`), copying these two parameters from the CPU to the GPU takes a significant amount of time and slows down training. The only possible situation this casting is necessary is if the user supplies a Tensor of eps / vmax values for each individual visibility value... which doesn't really make sense.

Also, I added an absolute bias function in `slar.analysis` for use in logging. This doesn't make too much sense to use for running in visibility values as this metric doesn't play well with values that run over many orders of magnitude, but it's helpful for things like calculating things like absolute p.e. bias across PMT spectra.