### PR TITLE
Add learning rate scheduler (optional) for SIREN training

### DIFF
--- a/slar/base.py
+++ b/slar/base.py
@@ -119,7 +119,7 @@ class Siren(nn.Module):
         
         self.net = nn.Sequential(*self.net)
     
-    def forward(self, coords, clone=True):
+    def forward(self, coords, clone=False):
         '''
         For the model forward computation.
 

--- a/slar/nets.py
+++ b/slar/nets.py
@@ -205,7 +205,7 @@ class SirenVis(Siren):
         return out
 
 
-    def save_state(self, filename, opt=None, epoch=0):
+    def save_state(self, filename, opt=None, sch=None, epoch=0):
         '''
         Stores the network model and optimizer (and some hyper-) parameters to a binary file.
 
@@ -216,6 +216,8 @@ class SirenVis(Siren):
             The name of checkpoint file to be stored.
         opt : torch.optim.Optimizer
             The optimizer instance to store the optimizer state in the same file.
+        sch : torch.optim.lr_scheduler, optional
+            Learing rate scheduler instance to adjust lr (update every epoch)
         epoch : float
             The epoch count of training.
         '''
@@ -233,6 +235,9 @@ class SirenVis(Siren):
 
         if opt:
             state_dict['optimizer'] = opt.state_dict()
+
+        if sch:
+            state_dict['scheduler'] = sch.state_dict()
 
         print('[SirenVis] saving the state ',filename)
         torch.save(state_dict,filename)
@@ -299,7 +304,3 @@ class SirenVis(Siren):
             self.register_buffer('scale', scale)
         else:
             self.register_parameter('scale', torch.nn.Parameter(scale))
-
-
-
-

--- a/slar/optimizers.py
+++ b/slar/optimizers.py
@@ -17,7 +17,7 @@ def get_lr(opt):
     for ps in opt.param_groups:
         return ps['lr']
 
-def load_optimizer_state(filename,opt):
+def load_optimizer_state(filename, opt, sch=None):
     '''
     Function to read the optimizer parameters from a checkpoint file.
 
@@ -27,6 +27,8 @@ def load_optimizer_state(filename,opt):
         The checkpoint file path+name to extract the optimizer state.
     opt : torch.optim.Optimizer
         The optimizer instance to load the parameters for.
+    sch : torch.optim.lr_scheduler, optional
+        Learning rate scheduler
 
     Returns
     -------
@@ -40,10 +42,13 @@ def load_optimizer_state(filename,opt):
         opt.load_state_dict(checkpoint['optimizer'])
         if 'epoch' in checkpoint.keys():
             epoch = int(checkpoint['epoch'])
+
+        if sch is not None:
+            sch.load_state_dict(checkpoint['scheduler'])
     return epoch
 
 
-def optimizer_factory(params,cfg):
+def optimizer_factory(params, cfg):
     '''
     Function to crate an optimizer for training siren
 
@@ -55,12 +60,19 @@ def optimizer_factory(params,cfg):
         The configuration parameters for this factory method. The 'optimizer_class'
         is the string name of an optimzier class. If 'resume' is True, 'ckpt_file'
         will be looked for loading the optimizer's state from the previous training.
-        
+
     Returns
     -------
-    torch.optim.Optimizer
+    opt: torch.optim.Optimizer
         An instance of an optimizer with the parameters eitehr configured
         by the input or loaded from a checkpoint file.
+
+    sch: torch.optim.lr_scheduler
+        An instance of learning rate scheduler, if 'scheduler_class' is given in the cfg.
+        Otherwise returns None
+
+    epoch: float
+        Current epoch. Restored from checkpoint for `resume=True`. 
     '''
     if 'optimizer_class' in cfg['train']:
         opt_class = cfg['train']['optimizer_class']
@@ -76,17 +88,59 @@ def optimizer_factory(params,cfg):
     print('[opt_factory] optimizer',opt_class)
     print('[opt_factory] parameters',opt_param)
 
+    sch = scheduler_factory(opt, cfg)
+
     epoch = 0
     if cfg['train'].get('resume'):
         ckpt_file = cfg['model'].get('ckpt_file')
         if not ckpt_file:
             raise RuntimeError('cannot "resume" without the model checkpoint file')
         print(f'[opt_factory] loading the optimizer state from {ckpt_file}')
-        epoch = load_optimizer_state(ckpt_file,opt)
-        if opt_param['lr']:
+        epoch = load_optimizer_state(ckpt_file, opt, sch)
+
+        if opt_param.get('lr', None) is not None:
             for p in opt.param_groups:
                 p['lr'] = opt_param['lr']
         print(f'[opt_factory] current lr = {get_lr(opt)}')
 
-    return opt, epoch
+    return opt, sch, epoch
 
+def scheduler_factory(opt, cfg):
+    '''
+    Factory to create learning rate scheduler.
+
+    Parameters
+    ----------
+    opt: torch.optim.Optimizer
+        An instance of optimizer.
+    cfg: dict
+        Confguration of a lr_scheduler.
+        'scheduler_class' - class name string in torch.optim.lr_scheduler
+        'scheduler_param' - keyword argumets passed to the scheduler contructor
+
+    Returns
+    -------
+    sch: torch.optim.lr_scheduler or None
+        An instance of lr scheduler. If 'scheduler_class' is not missing,
+        returns None.
+    '''
+    train_cfg = cfg.get('train', {})
+
+    sch_class = train_cfg.get('scheduler_class')
+    sch_param = train_cfg.get('scheduler_param', {})
+
+    if sch_class is None:
+        return None
+
+    if not hasattr(torch.optim.lr_scheduler, sch_class):
+        raise RuntimeError(
+            f'torch.optim.lr_scheduler has no scheduler called {sch_class}'
+        )
+
+    Scheduler = getattr(torch.optim.lr_scheduler, sch_class)
+    sch = Scheduler(opt, **sch_param)
+    
+    print('[opt_factory] scheduler', sch_class)
+    print('[opt_factory] parameters', sch_param)
+
+    return sch

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -9,9 +9,15 @@ import pytest
 def factory_cfg(rng):
     filename = writable_temp_file(suffix='.ckpt')
     lr = 10**rng.uniform(-6, -2)
-    cfg = {'train': {'optimizer_class': 'Adam', 
-                    'optimizer_param': {'lr': lr}}, 
-            'model': {'ckpt_file': filename}}
+    cfg = {
+        'train': {
+            'optimizer_class': 'Adam', 
+            'optimizer_param': {'lr': lr},
+            'scheduler_class': 'StepLR',
+            'scheduler_param': {'step_size': rng.integers(1, 10)},
+        },
+        'model': {'ckpt_file': filename}
+    }
     yield cfg
     os.remove(filename)
 
@@ -33,9 +39,16 @@ def test_load_optimizer_state(rng):
     assert epoch_loaded == epoch
 
 def test_optimizer_factory(factory_cfg, rng):
+    # test optimizer only
+    # remove scheduler from factory_cfg
+    cfg = factory_cfg.copy()
+    cfg['train'].pop('scheduler_class')
+    cfg['train'].pop('scheduler_param')
+
     params = [torch.randn(3, 5)]
-    opt, epoch = optimizer_factory(params, factory_cfg)
+    opt, sch, epoch = optimizer_factory(params, factory_cfg)
     assert isinstance(opt, torch.optim.Adam)
+    assert sch == None
     assert epoch == 0
     assert get_lr(opt) == factory_cfg['train']['optimizer_param']['lr']
 
@@ -44,9 +57,43 @@ def test_optimizer_factory(factory_cfg, rng):
     state = {'optimizer': opt.state_dict(), 'epoch': true_epoch}
 
     torch.save(state, factory_cfg['model']['ckpt_file'])
-    _cfg = factory_cfg.copy()
+    _cfg = cfg.copy()
     _cfg['train']['resume'] = True
-    opt, epoch = optimizer_factory(params, _cfg)
+    opt, sch, epoch = optimizer_factory(params, _cfg)
     assert isinstance(opt, torch.optim.Adam)
+    assert sch == None
     assert get_lr(opt) == _cfg['train']['optimizer_param']['lr']
     assert epoch == true_epoch
+
+def test_scheduler_factory(factory_cfg, rng):
+    params = [torch.randn(3, 5)]
+    opt, sch, epoch = optimizer_factory(params, factory_cfg)
+    assert isinstance(opt, torch.optim.Adam)
+    assert isinstance(sch, torch.optim.lr_scheduler.StepLR)
+    assert epoch == 0
+    assert get_lr(opt) == factory_cfg['train']['optimizer_param']['lr']
+
+    step_size = factory_cfg['train']['scheduler_param']['step_size']
+    for last_epoch in range(step_size+3):
+        opt.step()
+        sch.step()
+    last_lr = get_lr(opt)
+
+    state = {
+        'optimizer': opt.state_dict(), 
+        'scheduler': sch.state_dict(), 
+        'epoch': last_epoch,
+    }
+
+    torch.save(state, factory_cfg['model']['ckpt_file'])
+    _cfg = factory_cfg.copy()
+    _cfg['train']['resume'] = True
+
+    # drop lr from cfg; restore lr from checkpoint.
+    _cfg['train']['optimizer_param'].pop('lr')
+
+    opt, sch, epoch = optimizer_factory(params, _cfg)
+    assert isinstance(opt, torch.optim.Adam)
+    assert isinstance(sch, torch.optim.lr_scheduler.StepLR)
+    assert epoch == last_epoch
+    assert get_lr(opt) == last_lr


### PR DESCRIPTION
This pull request allows an optional lr scheduler for SIREN training.

An example to configure a lr scheduler:
```
...
train:
   scheduler_class: StepLR
   scheduler_param: 
      step_size: 10
      gamma: 0.1
...
```

The scheduler is updated every epoch in the train loop. 
If `scheduler_class` is omitted in the config, no scheduler will be created.
Additional tests are implemented in `tests/test_optimizers.py`.