### PR TITLE
Feat fast dataloader

### DIFF
--- a/slar/io.py
+++ b/slar/io.py
@@ -164,13 +164,14 @@ class PLibDataLoader:
                 raise NotImplementedError(f'Weight method {method} is invalid')
             self._weight_cfg = weight_cfg
         else:
-            self.get_weight = lambda vis : 1.
+            print('[PLibDataLoader] weight = 1')
+            self.get_weight = lambda vis : torch.tensor(1., device=device)
 
         # tranform visiblity in pseudo-log scale (default: False)
         xform_params = cfg.get('transform_vis')
         if xform_params:
-            print('[PhotonLibDataset] using log scale transformaion')
-            print('[PhotonLibDataset] transformation params',xform_params)
+            print('[PLibDataLoader] using log scale transformaion')
+            print('[PLibDataLoader] transformation params',xform_params)
 
         self.xform_vis, self.inv_xform_vis = partial_xform_vis(xform_params)
 
@@ -192,8 +193,9 @@ class PLibDataLoader:
 
             vis = self._plib.vis
             w = self.get_weight(vis)
+            target = self.xform_vis(vis)
 
-            self._cache = dict(position=pos, value=vis, weight=w)
+            self._cache = dict(position=pos, value=vis, weight=w, target=target)
 
     @property
     def device(self):
@@ -252,8 +254,9 @@ class PLibDataLoader:
                 pos = meta.norm_coord(meta.voxel_to_coord(vox_ids))
                 vis = self._plib[vox_ids]
                 w = self.get_weight(vis)
-                
-                output = dict(position=pos, value=vis, weight=w)
+                target = self.xform_vis(vis)
+
+                output = dict(position=pos, value=vis, weight=w, target=target)
                 yield output
         else:
             yield self._cache

--- a/slar/io.py
+++ b/slar/io.py
@@ -2,6 +2,7 @@ import torch
 from tqdm import tqdm
 from torch.utils.data import Dataset, DataLoader
 from slar.transform import partial_xform_vis
+from photonlib import PhotonLib
 
 class PhotonLibDataset(Dataset):
     """
@@ -90,4 +91,169 @@ class PhotonLibDataset(Dataset):
 
         return output
 
+class PLibDataLoader:
+    '''
+    A fast implementation of PhotonLib dataloader.
+    '''
+    def __init__(self, cfg, device=None):
+        '''
+        Constructor.
 
+        Arguments
+        ---------
+        cfg: dict
+            Config dictionary. See "Examples" bewlow.
+
+        device: torch.device (optional)
+            Device for the returned data. Default: None.
+        
+        Examples
+        --------
+        This is an example configuration in yaml format.
+
+        ```
+		photonlib:
+			filepath: plib_file.h5
+
+		data:
+			dataset:
+				weight:
+					method: vis
+					factor: 1000000.0
+					threshold: 1.0e-08
+			loader:
+				batch_size: 500
+				shuffle: true
+
+        transform_vis:
+            eps: 1.0e-05
+            sin_out: false
+            vmax: 1.0
+		```
+
+        The `photonlib` section provide the input file of `PhotonLib`.
+
+        [Optional] The `weight` subsection is the weighting scheme. Supported
+        schemes are: 
+        
+        1. `vis`, where `weight ~ 1/vis * factor`.  Weights below `threshold`
+        are set to one.  
+        2. To-be-implemented.
+
+        [Optional] The `loader` subsection mimics pytorch's `DataLoader` class,
+        however, only `batch_size` and `shuffle` options are implemented.  If
+        `loader` subsection is absent, the data loader returns the whole photon
+        lib in a single entry.
+
+        [Optional] The `transform_vis` subsection uses `log(vis+eps)` in the
+        training. The final output is scaled to `[0,1]`.
+        '''
+
+        # load plib to device
+        self._plib = PhotonLib.load(cfg).to(device)
+        
+        # get weighting scheme
+        weight_cfg = cfg.get('data',{}).get('dataset',{}).get('weight')
+        if weight_cfg:
+            method = weight_cfg.get('method')
+            if method == 'vis':
+                self.get_weight = self.get_weight_by_vis
+                print('[PLibDataLoader] weighting using', method)
+                print('[PLibDataLoader] params:', weight_cfg)
+            else:
+                raise NotImplementedError(f'Weight method {method} is invalid')
+            self._weight_cfg = weight_cfg
+        else:
+            self.get_weight = lambda vis : 1.
+
+        # tranform visiblity in pseudo-log scale (default: False)
+        xform_params = cfg.get('transform_vis')
+        if xform_params:
+            print('[PhotonLibDataset] using log scale transformaion')
+            print('[PhotonLibDataset] transformation params',xform_params)
+
+        self.xform_vis, self.inv_xform_vis = partial_xform_vis(xform_params)
+
+        # prepare dataloader
+        loader_cfg = cfg.get('data',{}).get('loader')
+        self._batch_mode = loader_cfg is not None
+
+        if self._batch_mode:
+            # dataloader in batches
+            self._batch_size = loader_cfg.get('batch_size', 1)
+            self._shuffle = loader_cfg.get('shuffle', False)
+        else:
+            # returns the whole plib in a single batch
+            n_voxels = len(self._plib)
+            vox_ids = torch.arange(n_voxels, device=device)
+
+            meta = self._plib.meta
+            pos = meta.norm_coord(meta.voxel_to_coord(vox_ids))
+
+            vis = self._plib.vis
+            w = self.get_weight(vis)
+
+            self._cache = dict(position=pos, value=vis, weight=w)
+
+    @property
+    def device(self):
+        return self._plib.device
+    
+    def get_weight_by_vis(self, vis):
+        '''
+        Weight by inverse visibility, `weight  = 1/vis * factor`.
+        Weights below `threshold` are set to 1.
+
+        Arguments
+        ---------
+        vis: torch.Tensor
+            Visibility values.
+
+        Returns
+        -------
+        w: trorch.Tensor
+            Weight values with `w.shape == vis.shape`.
+        '''
+        factor = self._weight_cfg.get('factor', 1.)
+        threshold = self._weight_cfg.get('threshold', 1e-8)
+        w = vis * factor
+        w[w<threshold] = 1.
+        return w
+        
+    def __len__(self):
+        '''
+        Number of batches.
+        '''
+        from math import ceil
+        if self._batch_mode:
+            return ceil(len(self._plib) / self._batch_size)
+
+        return 1
+        
+    def __iter__(self):
+        '''
+        Generator of batch data.
+
+        For non-batch mode, the whole photon lib is returned in a single entry
+        from the cache.
+        '''
+        if self._batch_mode:
+            meta = self._plib.meta
+            n_voxels = len(self._plib)
+            if self._shuffle:
+                vox_list = torch.randperm(n_voxels, device=self.device)
+            else:
+                vox_list = torch.arange(n_voxels, device=self.device)
+
+            for b in range(len(self)):
+                sel = slice(b*self._batch_size, (b+1)*self._batch_size)
+
+                vox_ids = vox_list[sel]
+                pos = meta.norm_coord(meta.voxel_to_coord(vox_ids))
+                vis = self._plib[vox_ids]
+                w = self.get_weight(vis)
+                
+                output = dict(position=pos, value=vis, weight=w)
+                yield output
+        else:
+            yield self._cache

--- a/slar/nets.py
+++ b/slar/nets.py
@@ -68,6 +68,10 @@ class SirenVis(Siren):
             print('[SirenVis] loading the state from ckpt. Only "network" configuration used.)')
             if ckpt_file is None:
                 ckpt_file = siren_cfg['ckpt_file']
+
+            # register buffer/parameter for output_scale
+            # actual values will be loaded from state_dict
+            self._init_output_scale(siren_cfg={})
             self.load_state(ckpt_file)
             return
 
@@ -190,12 +194,8 @@ class SirenVis(Siren):
                         xform_cfg   = self._xform_cfg,
                         aabox_ranges= self._meta.ranges,
                         do_hardsigmoid = self._do_hardsigmoid,
-                        input_scale = self.input_scale,
                        )
-        # check if output_scale should be saved
-        pnames = [ name for name, p in self.named_parameters()]
-        if not 'output_scale' in pnames:
-            state_dict['output_scale'] = self.output_scale 
+
         if opt:
             state_dict['optimizer'] = opt.state_dict()
 
@@ -219,32 +219,23 @@ class SirenVis(Siren):
 
         iteration = 0
         print('[SirenVis] loading the state',model_path)
-        with open(model_path, 'rb') as f:
 
-            checkpoint = torch.load(f, map_location='cpu')            
+        checkpoint = torch.load(model_path, map_location='cpu')            
 
-            from photonlib import AABox
-            self._meta = AABox(checkpoint['aabox_ranges'])
-            self._xform_cfg = checkpoint['xform_cfg']
-            self._xform_vis, self._inv_xform_vis = partial_xform_vis(self._xform_cfg)
-            self._do_hardsigmoid = checkpoint['do_hardsigmoid']
-            if 'input_scale' in checkpoint:
-                self.input_scale[:] = checkpoint['input_scale']
+        from photonlib import AABox
+        self._meta = AABox(checkpoint['aabox_ranges'])
+        self._xform_cfg = checkpoint['xform_cfg']
+        self._xform_vis, self._inv_xform_vis = partial_xform_vis(self._xform_cfg)
+        self._do_hardsigmoid = checkpoint['do_hardsigmoid']
 
-            output_scale = torch.ones(self._n_outs,dtype=torch.float32)
+        # 2024-03-10 kvt: for backward compatibility
+        state_dict = checkpoint['state_dict']
+        if 'input_scale' not in state_dict:
+            state_dict['input_scale'] = self.input_scale
+        if 'scale' in state_dict:
+            state_dict['output_scale'] = state_dict.pop('scale')
 
-            if 'scale' in checkpoint.keys():
-                # 2024-03-04 Kazu - For backward compatibility
-                self.register_buffer('output_scale', output_scale)
-                self.output_scale = checkpoint['scale']
-            if 'output_scale' in checkpoint.keys():
-                self.register_buffer('output_scale', output_scale)
-                self.output_scale = checkpoint['output_scale']
-            else:
-                self.register_parameter('output_scale', torch.nn.Parameter(output_scale))
-
-            self.load_state_dict(checkpoint['state_dict'])
-            
+        self.load_state_dict(state_dict)
 
     def _init_output_scale(self, siren_cfg):
 

--- a/slar/nets.py
+++ b/slar/nets.py
@@ -115,6 +115,17 @@ class SirenVis(Siren):
         '''
         return next(self.parameters()).device  
 
+    @property
+    def n_pmts(self):
+        '''
+        Number of pmts, same interface as `PhontonLib.n_pmts`.
+
+        Returns
+        -------
+        n_pmts: int
+            Number of PMTs (i.e. number of output features)
+        '''
+        return self._n_outs
 
     def update_meta(self, meta:AABox, input_scale:torch.Tensor=None):
         self._meta = meta

--- a/slar/train.py
+++ b/slar/train.py
@@ -2,7 +2,7 @@ import os
 from tqdm import tqdm
 import time
 import yaml
-from slar.io import PhotonLibDataset
+from slar.io import PLibDataLoader
 from slar.nets import SirenVis, WeightedL2Loss
 from slar.optimizers import optimizer_factory
 from slar.utils import CSVLogger, get_device
@@ -51,11 +51,9 @@ def train(cfg : dict):
     # Create necessary pieces: the model, optimizer, loss, logger.
     # Load the states if this is resuming.
     net = SirenVis(cfg).to(DEVICE)
-    ds = PhotonLibDataset(cfg)
-    if 'loader' in cfg['data']:
-        dl = DataLoader(ds, **cfg['data']['loader'])
-    else:
-        dl = [dict(position=ds.positions,value=ds.visibilities,weight=ds.weights)]
+
+    dl = PLibDataLoader(cfg, device=DEVICE)
+
     opt, sch, epoch = optimizer_factory(net.parameters(),cfg)
     if epoch >0:
         iteration_ctr = int(epoch * len(dl))
@@ -88,12 +86,13 @@ def train(cfg : dict):
             iteration_ctr += 1
             
             # Input data prep
-            x       = data['position'].to(DEVICE)
-            target  = data['value'].to(DEVICE)
-            weights = data['weight'].to(DEVICE)
-            
+            x              = data['position'].to(DEVICE)
+            target_linear  = data['value'].to(DEVICE)
+            weights        = data['weight'].to(DEVICE)
+            target         = dl.xform_vis(target_linear)
+
             twait = time.time()-twait
-            # Running hte model, compute the loss, back-prop gradients to optimize.
+            # Running the model, compute the loss, back-prop gradients to optimize.
             ttrain = time.time()
             pred   = net(x)
             loss   = criterion(pred, target, weights)
@@ -108,8 +107,7 @@ def train(cfg : dict):
             twait = time.time()
             
             # Step the logger
-            target_linear  = ds.inv_xform_vis(target)
-            pred_linear = ds.inv_xform_vis(pred)
+            pred_linear = dl.inv_xform_vis(pred)
             logger.step(iteration_ctr, target_linear, pred_linear)
                 
             # Save the model parameters if the condition is met

--- a/slar/train.py
+++ b/slar/train.py
@@ -87,9 +87,9 @@ def train(cfg : dict):
             
             # Input data prep
             x              = data['position'].to(DEVICE)
-            target_linear  = data['value'].to(DEVICE)
             weights        = data['weight'].to(DEVICE)
-            target         = dl.xform_vis(target_linear)
+            target         = data['target'].to(DEVICE)
+            target_linear  = data['value'].to(DEVICE)
 
             twait = time.time()-twait
             # Running the model, compute the loss, back-prop gradients to optimize.

--- a/tests/test_PLibDataLoader.py
+++ b/tests/test_PLibDataLoader.py
@@ -1,0 +1,83 @@
+from inspect import signature
+import yaml
+import torch
+import pytest
+from slar.io import PLibDataLoader
+from slar.transform import xform_vis, inv_xform_vis
+
+from tests.fixtures import rng, fake_photon_library
+
+@pytest.fixture
+def cfg_default(fake_photon_library):
+    cfg = yaml.safe_load(f'''
+    data:
+      dataset:
+        weight:
+          factor: 1.0e+8
+          method: vis
+          theshold: 1.0e-6
+      loader:
+        batch_size: 2
+        shuffle: true
+    photonlib:
+      filepath: {fake_photon_library} 
+    transform_vis:
+      eps: 1.0e-8
+      sin_out: True
+      vmax: 0.9
+
+    ''')
+    return cfg
+
+@pytest.fixture
+def cfg_empty(fake_photon_library):
+    cfg = yaml.safe_load(f'''
+    photonlib:
+       filepath: {fake_photon_library} 
+    ''')
+
+    return cfg
+
+def test_PLibDataLoader_ctor(cfg_default, cfg_empty):
+    ds = PLibDataLoader(cfg_default)
+    ds_empty = PLibDataLoader(cfg_empty)
+
+    for k,v in cfg_default['transform_vis'].items():
+        assert signature(ds.xform_vis).parameters[k].default==v, \
+            'xform_vis parameter(s) not assigned correctly'
+        assert signature(ds.inv_xform_vis).parameters[k].default==v, \
+            'inv_xform_vis parameter(s) not assigned correctly'
+
+    assert ds.get_weight==ds.get_weight_by_vis,  'incorrect weighing scheme'
+
+    assert ds._batch_mode, 'dataloader should be in batch mode'
+    assert not ds_empty._batch_mode, 'dataloader should not be in batch mode'
+
+
+def test_PLibDataLoader_getitem(cfg_default, cfg_empty):
+    ds_empty = PLibDataLoader(cfg_empty)
+
+    n_batch = 0
+    for batch in ds_empty:
+        n_batch += 1
+
+    plib = ds_empty._plib
+    assert n_batch==1, f'dataloader should only have 1 batch ({n_batch})'
+    assert torch.allclose(batch['value'], plib.vis), f'incorrect vis values'
+    assert batch['weight']==1, 'weight != 1'
+    
+    pos = batch['position']
+    assert torch.all((pos >=  -1) & (pos <= 1)), f'coordinates not normalized'
+
+    # ---------------------------------
+    ds = PLibDataLoader(cfg_default)
+
+    n_batch = 0
+    n_pts = 0
+    for batch in ds:
+        n_batch += 1
+        n_pts += len(batch['value'])
+
+    plib = ds_empty._plib
+    assert n_batch==len(ds), f'number of batches does not match'
+    assert n_pts==len(plib), f'nubmer of voxels does not match'


### PR DESCRIPTION
This is a feature branch contains a faster implementation of `PLibDataLoader`.

It is a *not* inherited  from pytorch's `DataLoader` class, but follows the style of input arguments.
Somebody passion enough could rewrite it, but it is good for its purpose for now.
Please read docstring for documentations.

Here are a summary of the pull requests:

1. New class `PLibDataLoader`, which load the photon lib for SIREN training in batch. Optionally it can also load the whole LUT in a single entry.
2. New pytest, `tests/test_PLibDataLoader.py`
3. Modified `train.py` to adopt the (small) changes of the data loader output.

