### PR TITLE
update ICARUS checkpoint file

### DIFF
--- a/bin/download_icarus_ckpt.sh
+++ b/bin/download_icarus_ckpt.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# v0.1 ... iteration-127500-epoch-7500.ckpt ... ID = 1OckQGtwWaEViQJlPZc0DOjeLj7s5IKHR
-#
-#wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1OckQGtwWaEViQJlPZc0DOjeLj7s5IKHR' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1OckQGtwWaEViQJlPZc0DOjeLj7s5IKHR" -O icarus_siren.ckpt
-#gdown https://drive.google.com/uc?id=1OckQGtwWaEViQJlPZc0DOjeLj7s5IKHR -O icarus_siren.ckpt
-gdown https://drive.google.com/uc?id=1uR5w9P0Gi1H1bM-rVZUrOOPxiq24clvs -O icarus_siren.ckpt
+
+# icarus_2024-11-18.ckpt
+gdown 1kAfLQwvSHRY1KBR2PtgtdTBVfbqCMpey -O icarus_siren.ckpt


### PR DESCRIPTION
Update download script for ICARUS checkpoint.
Requires for ICARUS tutorial section 2.2 using latest codes.